### PR TITLE
revisions for blender and nuke

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -448,22 +448,26 @@ paths:
     nuke_shot_publish:
         definition: '@shot_root/publish/nuke/{Shot}_{task_name}_v{version}.nk'
     # write node outputs
-    nuke_shot_render_mono_dpx:
+    ## DPX ##
+    nuke_shot_render_dpx:
         definition: '@shot_render_area_nuke/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_v{version}.{SEQ}.dpx'
-    nuke_shot_render_pub_mono_dpx:
+    nuke_shot_render_pub_dpx:
         definition: '@shot_root/publish/elements/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_v{version}.{SEQ}.dpx'
-    nuke_shot_render_mono_jpg:
+    ## JPG ##
+    nuke_shot_render_jpg:
         definition: '@shot_render_area_nuke/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_v{version}.{SEQ}.jpg'
-    nuke_shot_render_pub_mono_jpg:
+    nuke_shot_render_pub_jpg:
         definition: '@shot_root/publish/elements/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_v{version}.{SEQ}.jpg'
-    nuke_shot_render_mono_exr:
+    ## COMP EXR ##
+    nuke_shot_render_exr:
+        definition: '@shot_render_area_nuke/{task_name}/{Shot}_{task_name}_v{version}/{width}x{height}/{Shot}_{task_name}_v{version}.{SEQ}.exr'
+    nuke_shot_render_pub_exr:
+        definition: '@shot_root/publish/elements/{task_name}/{Shot}_{task_name}_v{version}/{width}x{height}/{Shot}_{task_name}_v{version}.{SEQ}.exr'
+    ## ELEMENT EXR ##
+    nuke_shot_render_element_exr:
         definition: '@shot_render_area_nuke/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_v{version}.{SEQ}.exr'
-    nuke_shot_render_pub_mono_exr:
+    nuke_shot_render_pub_element_exr:
         definition: '@shot_root/publish/elements/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_v{version}.{SEQ}.exr'
-    nuke_shot_render_stereo:
-        definition: '@shot_render_area_nuke/{task_name}/{Shot}_{task_name}_{nuke.output}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_{eye}_v{version}.{SEQ}.exr'
-    nuke_shot_render_pub_stereo:
-        definition: '@shot_root/publish/elements/{task_name}/{Shot}_{task_name}_{nuke.output}_{eye}_v{version}/{width}x{height}/{Shot}_{task_name}_{nuke.output}_{eye}_v{version}.{SEQ}.exr'
     # review output
     shot_quicktime_quick:
         definition: '@shot_root/resources/review/quickdaily/{Shot}_{task_name}_{iteration}.mov'
@@ -499,7 +503,7 @@ paths:
         definition: '@shot_publish_area_blender/scenes/@blender_shot_pd.blend'
 
     blender_shot_render:
-        definition: '@shot_render_area_blender/@blender_shot_pd/{blender.scene}/{Shot}_{task_name}-{name}-{blender.scene}_v{version}.{SEQ}'
+        definition: '@shot_render_area_blender/@blender_shot_pd/{blender.scene}/{Shot}_{task_name}_{name}_{blender.scene}_v{version}.{SEQ}'
 
 
     ##########################################################################################
@@ -741,7 +745,7 @@ paths:
 
     # Location of renders for assets
     blender_asset_render:
-        definition: '@asset_render_area_blender/@blender_asset_pd/{blender.scene}/{Asset}_{task_name}-{name}-{blender.scene}_v{version}.{SEQ}'
+        definition: '@asset_render_area_blender/@blender_asset_pd/{blender.scene}/{Asset}_{task_name}_{name}_{blender.scene}_v{version}.{SEQ}'
 
 
 #
@@ -768,7 +772,7 @@ strings:
     mari_asset_project_name: "{mari.project_name} - Asset {asset_name}, {task_name}"
 
     #blender shot filename
-    blender_shot_pd: "{Shot}_{task_name}-{name}_v{version}"
+    blender_shot_pd: "{Shot}_{task_name}_{name}_v{version}"
 
     #blender Asset filename
-    blender_asset_pd: "{Asset}_{task_name}-{name}_v{version}"
+    blender_asset_pd: "{Asset}_{task_name}_{name}_v{version}"

--- a/env/includes/settings/tk-multi-loader2.yml
+++ b/env/includes/settings/tk-multi-loader2.yml
@@ -158,6 +158,7 @@ settings.tk-multi-loader2.nuke:
     Nuke Script: [script_import]
     Photoshop Image: [read_node]
     Rendered Image: [read_node]
+    Hiero Plate: [read_node]
     Texture: [read_node]
   entities:
   - caption: Assets

--- a/env/includes/settings/tk-nuke-writenode.yml
+++ b/env/includes/settings/tk-nuke-writenode.yml
@@ -28,63 +28,51 @@ settings.tk-nuke-writenode.asset:
     settings: {}
     tank_type: Rendered Image
     tile_color: []
-    promote_write_knobs: []
+    promote_write_knobs: [datatype, compression]
   location: "@apps.tk-nuke-writenode.location"
 
 # shot
 settings.tk-nuke-writenode.shot:
   template_script_work: nuke_shot_work
   write_nodes:
-  - file_type: exr
-    name: Stereo Exr, 32 bit
-    proxy_publish_template:
-    proxy_render_template:
-    publish_template: nuke_shot_render_pub_stereo
-    render_template: nuke_shot_render_stereo
-    settings:
-      datatype: 32 bit float
-    tank_type: Rendered Image
-    tile_color: []
-    promote_write_knobs: []
-  - file_type: exr
-    name: Stereo Exr, 16 bit
-    promote_write_knobs: []
-    proxy_publish_template:
-    proxy_render_template:
-    publish_template: nuke_shot_render_pub_stereo
-    render_template: nuke_shot_render_stereo
-    settings:
-      datatype: 16 bit half
-    tank_type: Rendered Image
-    tile_color: []
   - file_type: dpx
-    name: Mono Dpx
+    name: Dpx
     promote_write_knobs: []
     proxy_publish_template:
     proxy_render_template:
-    publish_template: nuke_shot_render_pub_mono_dpx
-    render_template: nuke_shot_render_mono_dpx
+    publish_template: nuke_shot_render_pub_dpx
+    render_template: nuke_shot_render_dpx
     settings: {}
     tank_type: Rendered Image
     tile_color: []
   - file_type: jpg
-    name: Mono Jpg
+    name: Jpg
     promote_write_knobs: []
     proxy_publish_template:
     proxy_render_template:
-    publish_template: nuke_shot_render_pub_mono_jpg
-    render_template: nuke_shot_render_mono_jpg
+    publish_template: nuke_shot_render_pub_jpg
+    render_template: nuke_shot_render_jpg
     settings: {}
     tank_type: Rendered Image
     tile_color: []
   - file_type: exr
-    name: Mono Exr
-    promote_write_knobs: []
+    name: Comp Exr
     proxy_publish_template:
     proxy_render_template:
-    publish_template: nuke_shot_render_pub_mono_exr
-    render_template: nuke_shot_render_mono_exr
+    publish_template: nuke_shot_render_pub_exr
+    render_template: nuke_shot_render_exr
     settings: {}
     tank_type: Rendered Image
     tile_color: []
+    promote_write_knobs: [datatype, compression]
+  - file_type: exr
+    name: Element Exr
+    proxy_publish_template:
+    proxy_render_template:
+    publish_template: nuke_shot_render_pub_element_exr
+    render_template: nuke_shot_render_element_exr
+    settings: {}
+    tank_type: Rendered Image
+    tile_color: []
+    promote_write_knobs: [datatype, compression]
   location: "@apps.tk-nuke-writenode.location"


### PR DESCRIPTION
Revised the blender naming convention to change dashes to underscores.  removed all the render options for mono vs stereo in nuke and created a new templete for Comp EXR and Element EXR.  Also added hiero plate to the loader now for nuke. also made the nuke write node now capable of selecting compression